### PR TITLE
There was a bug where the toolbar buttons had no background in some cases and also reply was showing through post window.

### DIFF
--- a/modules/postWindow.less
+++ b/modules/postWindow.less
@@ -4,6 +4,7 @@
 	height: 350px;
 	visibility: hidden;
 	width: 100%;
+	z-index: 10 !important;
 
 	> div {
 		position: absolute;
@@ -19,12 +20,16 @@
 
 
 		.btn-toolbar {
+			.btn{
+				background: #c0c0c0;
+			}
+
 			&.formatting-bar {
 				.no-select;
 
 				width: 90%;
 				margin: 0 auto 8px auto;
-
+				.btn{ background: transparent;}
 				span {
 					color: white;
 


### PR DESCRIPTION
Adding a default background color to toolbar buttons and adjusting z-index of post window, to prevent reply-button show through bug
