### PR TITLE
Add relative path to alternate logins url

### DIFF
--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -65,7 +65,7 @@
 			<h4>[[login:alternative_logins]]</h4>
 			<ul class="alt-logins">
 				<!-- BEGIN authentication -->
-				<li class="{authentication.name}"><a rel="nofollow" href="{authentication.url}"><i class="fa fa-{authentication.icon}-square fa-3x"></i></a></li>
+				<li class="{authentication.name}"><a rel="nofollow" href="{relative_path}{authentication.url}"><i class="fa fa-{authentication.icon}-square fa-3x"></i></a></li>
 				<!-- END authentication -->
 			</ul>
 		</div>


### PR DESCRIPTION
Most of the SSO providers does not add relative_path to the url they register, so I think it should have added here.
