### PR TITLE
Autocorrect & Autocapitalise for iOS

### DIFF
--- a/templates/login.tpl
+++ b/templates/login.tpl
@@ -21,7 +21,7 @@
 				<div class="form-group">
 					<label for="username" class="col-lg-2 control-label">[[login:username]]</label>
 					<div class="col-lg-10">
-						<input class="form-control" type="text" placeholder="[[login:username]]" name="username" id="username" />
+						<input class="form-control" type="text" placeholder="[[login:username]]" name="username" id="username" autocorrect="off" autocapitalize="off" />
 					</div>
 				</div>
 				<div class="form-group">


### PR DESCRIPTION
This (should) solve the autocorrect on usernames as well as the autocapitalisation (is that even a word) of the first letter of a username.
