### PR TITLE
Changes to Android default.

### DIFF
--- a/templates/partials/share_dropdown.tpl
+++ b/templates/partials/share_dropdown.tpl
@@ -14,6 +14,6 @@
 	</li>
 	<!-- ENDIF !config.disableSocialButtons -->
 	<li class="text-center">
-		<input id="category-link" type="text" value="" class="form-control post-link inline-block"></input>
+		<input id="category-link" readonly="true" type="text" value="" class="form-control post-link inline-block"></input>
 	</li>
 </ul>


### PR DESCRIPTION
Prevents Android from opening the keyboard when you click the share button. Also prevents the link from being altered to avoid possible 404s.