### PR TITLE
Add rel="noopener"

### DIFF
--- a/templates/partials/cookie-consent.tpl
+++ b/templates/partials/cookie-consent.tpl
@@ -1,4 +1,4 @@
 <div class="cookie-consent">
     <button class="pull-right btn btn-primary">{dismiss}</button>
-    {message} <a target="_blank" href="{link_url}">{link}</a>
+    {message} <a target="_blank" rel="noopener" href="{link_url}">{link}</a>
 </div>


### PR DESCRIPTION
It's a good practice to make target="_blank" links to cross-origin destination not give any control over original window to the site that's opened if it's not needed. And it's not needed here.
Also, lighthouse complains about it, so this small change will improve the "Best Practices" score there :)
Added here too because julianlam suggested it:
> Can you also PR vanilla theme?